### PR TITLE
update the deployed url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <div align="center">
   <a
     alt="Epic Web logo with the words Deployed Version"
-    href="https://epicweb-dev-testing-fundamentals.fly.dev/"
+    href="https://testing-fundamentals.epicweb.dev/"
   >
     <img
       width="300px"


### PR DESCRIPTION
I've noticed the deployed version badge in the readme was still pointing to the WIP deployment. Updating it to point to production. 