### PR TITLE
03-02: fix incorrect promise chaining

### DIFF
--- a/exercises/03.async/02.solution.rejections/README.mdx
+++ b/exercises/03.async/02.solution.rejections/README.mdx
@@ -20,9 +20,36 @@ I make sure that the passed `actual` value is the instance of Promise:
 
 Now that we are always asserting on a Promise, I will make sure it rejects, and compare the expected and the actual error messages once it does.
 
-<CodeFile file="setup.ts" range="22-40" highlight="29-38" />
+```ts nonumber lines=7-11
+rejects: {
+  toThrow(expected) {
+    if (!(actual instanceof Promise)) {
+			throw new Error(`Expected ${actual} to be a promise`)
+		}
 
-> To handle false-positive scenarios, I add a `.then()` callback that always throws. This means that if the given `actual` promise resolves, the `expect(actual).rejects.toThrow()` assertion will reject, which is exactly what we want.
+    return actual.catch((error) => {
+      if (error.message !== expected.message) {
+        throw new Error(`Expected error message to be ${error.message} but got ${expected}`)
+      }
+    })
+  }
+}
+```
+
+<callout-warning>In the video, I made a mistake at 02:00! The handling of fasle-positive scenarios must be done via `.then(onFulfilled, onRejected)` callback, not via the `.then().catch()` chaining. See the correct implementation below, and feel free to skip to 02:28 to watch the rest of the solution.</callout-warning>
+
+To handle the unwanted cases when the `actual` promise resolves, I will replace the `.catch()` callback with a single `.then()` callback, providing it with two arguments:
+
+```ts remove=1 add=2
+return actual.catch(onRejected)
+return actual.then(onFulfilled, onRejected)
+```
+
+The `onFulfilled` function will be executed when the `actual` promise resolves, and I will throw an error if that happens. The `onRejected` function will be the same we've provided to the `.catch()` method before.
+
+<CodeFile file="setup.ts" range="22-40" highlight="29-31" />
+
+> Using a single `.then()` callback allow me to handle the promise fulfillment/rejection _without introducing a chain_. You can learn more about why this is important in [this issue](https://github.com/epicweb-dev/testing-fundamentals/issues/17).
 
 Finally, I change the test case to use the newly created `.rejects.toThrow()` assertion and provide the expected error:
 

--- a/exercises/03.async/02.solution.rejections/setup.ts
+++ b/exercises/03.async/02.solution.rejections/setup.ts
@@ -25,17 +25,18 @@ globalThis.expect = function (actual: unknown) {
 					throw new Error(`Expected ${actual} to be a promise`)
 				}
 
-				return actual
-					.then(() => {
+				return actual.then(
+					() => {
 						throw new Error(`Expected ${actual} to reject but it didn't`)
-					})
-					.catch(error => {
+					},
+					error => {
 						if (error.message !== expected.message) {
 							throw new Error(
 								`Expected ${error.message} to equal to ${expected.message}`,
 							)
 						}
-					})
+					},
+				)
 			},
 		},
 	}


### PR DESCRIPTION
- Fixes #17 

## Changes

- Adds a warning callout to alert the student that I've made a mistake on the video. I include the exact timestamp where the mistake happens and also the timeframe to which they can skip to continue watching. 
- Rewrites the solution explanation. Elaborates a bit more on `.then(x, y)` vs `.catch()` difference. 
- Links to the related GitHub issues if they wish to learn more about the context around this change. 