### PR TITLE
setup script moved under epicshop fix.

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -1,1 +1,1 @@
-import './scripts/setup.js'
+import './epicshop/setup.js'


### PR DESCRIPTION
Hi @kentcdodds  i was setting up project locally, and getting "ERR_MODULE_NOT_FOUND".  setup.js was pointed to "scripts" folder, but there is no folder with name scripts and it has been moved under "epicshop" folder. 