### PR TITLE
Fix global test return type

### DIFF
--- a/exercises/03.async/01.solution.await/setup.ts
+++ b/exercises/03.async/01.solution.await/setup.ts
@@ -4,7 +4,7 @@ interface Assertions {
 
 declare global {
 	var expect: (actual: unknown) => Assertions
-	var test: (title: string, callback: () => void) => void
+	var test: (title: string, callback: () => void | Promise<void>) => void
 	var beforeAll: (callback: () => void) => void
 	var afterAll: (callback: () => void) => void
 }


### PR DESCRIPTION
It's just a small fix for the global test return type. Without this, my IDE gave warning

`'await' has no effect on the type of this expression.` on the await callback in `globalThis.test`