### PR TITLE
use consistent Promise<T> return type for callback

### DIFF
--- a/exercises/03.async/01.solution.await/README.mdx
+++ b/exercises/03.async/01.solution.await/README.mdx
@@ -10,6 +10,10 @@ This will allow me to await the `callback()` if it happens to be `async` too.
 
 <CodeFile file="setup.ts" range="22-26" highlight="24" />
 
+<callout-info>To let TypeScript know that `callback` is now, potentially, an asynchronous function, I will adjust its return type to include `Promise<void>`:</callout-info>
+
+<CodeFile file="setup.ts" range="5-10" highlight="7" />
+
 If I run the tests now, I can correctly see the assertion on `greetByResponse()` failing the relevant test:
 
 ```txt nocopy nonumber lines=3-4

--- a/exercises/03.async/02.problem.rejections/setup.ts
+++ b/exercises/03.async/02.problem.rejections/setup.ts
@@ -10,7 +10,7 @@ interface Assertions {
 
 declare global {
 	var expect: (actual: unknown) => Assertions
-	var test: (title: string, callback: () => void) => void
+	var test: (title: string, callback: () => void | Promise<void>) => void
 	var beforeAll: (callback: () => void) => void
 	var afterAll: (callback: () => void) => void
 }

--- a/exercises/03.async/02.solution.rejections/setup.ts
+++ b/exercises/03.async/02.solution.rejections/setup.ts
@@ -7,7 +7,7 @@ interface Assertions {
 
 declare global {
 	var expect: (actual: unknown) => Assertions
-	var test: (title: string, callback: () => void) => void
+	var test: (title: string, callback: () => void | Promise<void>) => void
 	var beforeAll: (callback: () => void) => void
 	var afterAll: (callback: () => void) => void
 }

--- a/exercises/03.async/03.problem.waitFor/setup.ts
+++ b/exercises/03.async/03.problem.waitFor/setup.ts
@@ -7,7 +7,7 @@ interface Assertions {
 
 declare global {
 	var expect: (actual: unknown) => Assertions
-	var test: (title: string, callback: () => void) => void
+	var test: (title: string, callback: () => void | Promise<void>) => void
 	var beforeAll: (callback: () => void) => void
 	var afterAll: (callback: () => void) => void
 }

--- a/exercises/03.async/03.solution.waitFor/setup.ts
+++ b/exercises/03.async/03.solution.waitFor/setup.ts
@@ -7,7 +7,7 @@ interface Assertions {
 
 declare global {
 	var expect: (actual: unknown) => Assertions
-	var test: (title: string, callback: () => void) => void
+	var test: (title: string, callback: () => void | Promise<void>) => void
 	var beforeAll: (callback: () => void) => void
 	var afterAll: (callback: () => void) => void
 }

--- a/exercises/04.vitest/01.problem.using-vitest/setup.ts
+++ b/exercises/04.vitest/01.problem.using-vitest/setup.ts
@@ -7,7 +7,7 @@ interface Assertions {
 
 declare global {
 	var expect: (actual: unknown) => Assertions
-	var test: (title: string, callback: () => void) => void
+	var test: (title: string, callback: () => void | Promise<void>) => void
 	var beforeAll: (callback: () => void) => void
 	var afterAll: (callback: () => void) => void
 }


### PR DESCRIPTION
- Follow-up to #22. Now all exercises after 03/01 annotate the return type of the `callback` argument as potentially async. 
- Adds a callout about the return type change so it's apparent to the developer. 