### PR TITLE
fix: typo in lecture 02-04 instructions

### DIFF
--- a/exercises/02.test-structure/04.problem.hooks/README.mdx
+++ b/exercises/02.test-structure/04.problem.hooks/README.mdx
@@ -51,4 +51,4 @@ This problem illustrates the importance of the testing setup for the quality of 
 
 <callout-success class="important">A test must fail if, and only if, the intention behind the system is not met.</callout-success>
 
-🦉 It's a fantastic rule to keep in mind when writing tests. Learn more about [The Golden Rule of Assertion](https://www.epicweb.dev/the-golden-rule-of-assertions) and how it can help you write better tests every single tim.
+🦉 It's a fantastic rule to keep in mind when writing tests. Learn more about [The Golden Rule of Assertion](https://www.epicweb.dev/the-golden-rule-of-assertions) and how it can help you write better tests every single time.


### PR DESCRIPTION
Fixes a typo inside the instructions of lecture 02-04